### PR TITLE
Refactor and improve affine handling in the viewer.

### DIFF
--- a/napari_nibabel/_tests/test_nibabel.py
+++ b/napari_nibabel/_tests/test_nibabel.py
@@ -17,8 +17,11 @@ def test_reader(tmp_path):
 
     # write some fake data in NIFTI-1 format
     my_test_file = str(tmp_path / "myfile.nii")
-    original_data = np.random.rand(20, 20)
-    nii = nib.Nifti1Image(original_data, affine=np.eye(4))
+    original_data = np.random.rand(20, 20, 1)
+
+    # Set affine to an LPS affine here so internal reorientation will not be
+    # needed.
+    nii = nib.Nifti1Image(original_data, affine=np.diag((-1, -1, 1, 1)))
     nii.to_filename(my_test_file)
     np.save(my_test_file, original_data)
 

--- a/napari_nibabel/nibabel.py
+++ b/napari_nibabel/nibabel.py
@@ -233,7 +233,7 @@ def reader_function(path):
     affine_plumb_spl[2, 2] = -affine_plumb[0, 0]  # flip R->L, move L last
     # make the same order and sign flips to the translations
     affine_plumb_spl[:3, 3] = affine_plumb[2::-1, 3]
-    affine_plumb_spl[2:4, 3] *= -1  # flip R->L, A->P
+    affine_plumb_spl[1:3, 3] *= -1  # flip R->L, A->P
     # reverse order of the last 3 data dimensions correspondingly
     data = data.transpose(tuple(range(0, data.ndim - 3)) + (-1, -2, -3))
 

--- a/napari_nibabel/nibabel.py
+++ b/napari_nibabel/nibabel.py
@@ -19,10 +19,96 @@ from napari_plugin_engine import napari_hook_implementation
 
 from nibabel.imageclasses import all_image_classes
 from nibabel.filename_parser import splitext_addext
+from nibabel.orientations import (io_orientation, inv_ornt_aff,
+                                  apply_orientation)
+
+valid_volume_exts = {klass.valid_exts for klass in all_image_classes}
+valid_volume_exts = set(functools.reduce(operator.add, valid_volume_exts))
 
 
-all_valid_exts = {klass.valid_exts for klass in all_image_classes}
-all_valid_exts = set(functools.reduce(operator.add, all_valid_exts))
+def reorder_axes_to_ras(affine, data):
+    """Permutes data dimensions and updates the affine accordingly.
+
+    Reorders and/or flips data axes to get the spatial axes in RAS+ order.
+    For oblique scans the axes closest to RAS (Right-Anterior-Superior) as
+    determined by ``nibabel.affine.io_orientation``.
+
+    Parameters
+    ----------
+    affine : (4, 4) ndarray
+        Affine matrix
+    data : ndarray
+        Data array. Spatial dimensions must be first.
+
+    Returns
+    -------
+    affine_ras : (4, 4) ndarray
+        The affine matrix for the RAS-space data.
+    data_ras : (4, 4) ndarray
+        Data with axes reordered and/or flipped to RAS+ order.
+
+    Notes
+    -----
+    Adapted from code converting to LAS+ in nibabel's parrec2nii.py
+    """
+
+    # Reorient data block to RAS+ if necessary
+    ornt = io_orientation(affine)
+    if np.all(ornt == [[0, 1],
+                       [1, 1],
+                       [2, 1]]):
+        # already in desired orientation
+        return affine, data
+
+    # Reorient to RAS+
+    t_aff = inv_ornt_aff(ornt, data.shape)
+    affine_ras = np.dot(affine, t_aff)
+
+    ornt = np.asarray(ornt)
+    data_ras = apply_orientation(data, ornt)
+    return affine_ras, data_ras
+
+
+def adjust_translation(affine, affine_plumb, data_shape):
+    """Adjust translation vector of affine_plumb.
+
+    The goal is to have affine_plumb result in the same data center
+    point in world coordinates as the original affine.
+
+    Parameters
+    ----------
+    affine : ndarray
+        The shape (4, 4) affine matrix read in by nibabel.
+    affine_plumb: ndarray
+        The affine after permutation to RAS+ space followed by discarding
+        of any rotation/shear elements.
+    data_shape : tuple of int
+        The shape of the data array
+
+    Returns
+    -------
+    affine_plumb : ndarray
+        A copy of affine_plumb with the 3 translation elements updated.
+    """
+    data_shape = data_shape[-3:]
+    if len(data_shape) < 3:
+        # TODO: prepend or append?
+        data_shape = data_shape + (1,) * (3 - data.ndim)
+
+    # get center in world coordinates for the original RAS+ affine
+    center_ijk = (np.array(data_shape) - 1) / 2
+    center_world = np.dot(affine[:3, :3], center_ijk) + affine[:3, 3]
+
+    # make a copy to avoid in-place modification of affine_plumb
+    affine_plumb = affine_plumb.copy()
+
+    # center in world coordinates with the current affine_plumb
+    center_world_plumb =  np.dot(affine_plumb[:3, :3], center_ijk)
+
+    # adjust the translation elements
+    affine_plumb[:3, 3] = center_world - center_world_plumb
+    return affine_plumb
+
 
 @napari_hook_implementation
 def napari_get_reader(path):
@@ -48,7 +134,7 @@ def napari_get_reader(path):
     froot, ext, addext = splitext_addext(path)
 
     # if we know we cannot read the file, we immediately return None.
-    if not ext.lower() in all_valid_exts:
+    if not ext.lower() in valid_volume_exts:
         return None
 
     # otherwise we return the *function* that can read ``path``.
@@ -82,17 +168,28 @@ def reader_function(path):
     paths = [path] if isinstance(path, str) else path
 
     n_spatial = 3
+
     # note: we don't squeeze the data below, so 2D data will be 3D with 1 slice
     if len(paths) > 1:
         # load all files into a single array
         objects = [nib.load(_path) for _path in paths]
         header = objects[0].header
         affine = objects[0].affine
-        if not all([_obj.shape == _obj[0].shape for _obj in objects]):
+        if not all([_obj.shape == objects[0].shape for _obj in objects]):
             raise ValueError(
                 "all selected files must contain data of the same shape")
 
+        if not all(np.allclose(affine, _obj.affine) for _obj in objects):
+            raise ValueError(
+                "all selected files must share a common affine")
+
         arrays = [_obj.get_fdata() for _obj in objects]
+
+        # apply same transform to all volumes in the stack
+        affine_orig = affine.copy()
+        for i, arr in enumerate(arrays):
+            affine, arr_ras = reorder_axes_to_ras(affine_orig, arr)
+            arrays[i] = arr_ras
 
         # stack arrays into single array
         data = np.stack(arrays)
@@ -101,6 +198,8 @@ def reader_function(path):
         header = img.header
         affine = img.affine
         data = img.get_fdata()  # keep this as dataobj or use get_fdata()?
+
+        affine, data = reorder_axes_to_ras(affine, data)
 
         spatial_axis_order = tuple(range(n_spatial))
         if data.ndim > 3:
@@ -114,43 +213,32 @@ def reader_function(path):
             if spatial_axis_order != (0, 1, 2):
                 data = data.transpose(spatial_axis_order[:data.ndim])
 
-    try:
-        # only get zooms for the spatial axes
-        zooms = np.asarray(header.get_zooms())[:n_spatial]
-        if np.any(zooms == 0):
-            raise ValueError("invalid zoom = 0 found in header")
-        # normalize so values are all >= 1.0 (not strictly necessary)
-        # zooms = zooms / zooms.min()
-        zooms = tuple(zooms)
-        if data.ndim > 3:
-            zooms = (1.0, ) * (data.ndim - n_spatial) + zooms
-    except (AttributeError, ValueError):
-        zooms = (1.0, ) * data.ndim
-
-    apply_translation = False
-    if apply_translation:
-        translate = tuple(affine[:n_spatial, 3])
-        if data.ndim > 3:
-            # set translate = 0.0 on non-spatial dimensions
-            translate = (0.0,) * (data.ndim - n_spatial) + translate
+    if np.all(affine[:3, :3] == (np.eye(3) * affine[:3, :3])):
+        # no rotation or shear components
+        affine_plumb = affine
     else:
-        translate = (0.0,) * data.ndim
+        # Set any remaining non-diagonal elements of the affine to 0
+        # (napari currently cannot display with rotate/shear)
+        affine_plumb = np.diag(np.diag(affine))
 
-    # optional kwargs for the corresponding viewer.add_* method
-    # https://napari.org/docs/api/napari.components.html#module-napari.components.add_layers_mixin
-    # see also: https://napari.org/tutorials/fundamentals/image
+        # Set translation elements of affine_plumb to get the center of the
+        # data cube in the same position in world coordinates
+        affine_plumb = adjust_translation(affine, affine_plumb, data.shape)
+
+    # Note: The translate, scale, rotate, shear kwargs correspond to the
+    # 'data2physical' component of a composite affine transform.
+    # https://github.com/napari/napari/blob/v0.4.11/napari/layers/base/base.py#L254-L268   #noqa
+    # However, the affine kwarg corresponds instead to the 'physical2world'
+    # affine. Here, we will extract the scale and translate components from
+    # affine_plumb so that we are specifying 'data2physical' to napari.
+
     add_kwargs = dict(
         metadata=dict(affine=affine, header=header),
         rgb=False,
-        scale=zooms,
-        translate=translate,
-        # contrast_limits=,
+        scale=np.diag(affine_plumb[:3, :3]),
+        translate=affine_plumb[:3, 3],
+        affine=None,
+        channel_axis=None,
     )
 
-    # TODO: potential kwargs to set for viewer.add_image
-    #     contrast_limits kwarg based on info in image header?
-    #          e.g. for NIFTI: nii.header._structarr['cal_min']
-    #                          nii.header._structarr['cal_max']
-
-    layer_type = "image"  # optional, default is "image"
-    return [(data, add_kwargs, layer_type)]
+    return [(data, add_kwargs, "image")]

--- a/napari_nibabel/nibabel.py
+++ b/napari_nibabel/nibabel.py
@@ -145,7 +145,7 @@ def reader_function(path):
                 "all selected files must share a common affine")
         # reorient volumes to the desired orientation
         transform_ornt = get_transform_ornt(affine, target=('L', 'P', 'S'))
-        objects = [_obj.as_reoriented(transform_ornt)]
+        objects = [_obj.as_reoriented(transform_ornt) for _obj in objects]
         arrays = [_obj.get_fdata() for _obj in objects]
         affine = objects[0].affine
         header = objects[0].header


### PR DESCRIPTION
This PR resorts axes to RAS order to avoid potential errors in affine slicing in Napari (see napari/napari#3410). Also, any rotation/shear elements are discarded so that the napari sliders just correspond to simple slicing of the array.  This results is an affine that is diagonal in the upper left 3x3 matrix.

I then swap and flip signs to go from RAS to SPL order (as suggested in #5) so that upon initially opening the viewer, the axial view is displayed in a normal radiological orientation. I hope to revisit orientation of linked orthogonal views in napari itself in the coming months.

One issue not updated in this PR was what metadata we want to pass to the viewer. We were passing the affine and header from the NIFTI, but now this will no longer match after reordering/flip of the dimensions. I don't think we have to address that in this PR, thouth, as that metadata was passed along for convenience, but is not being used by napari itself.

@ch-n: if you get a chance to test this out, does it operate as you expect?